### PR TITLE
Fix uploadFile that use ContentVersion API

### DIFF
--- a/lib/PropelConnect.js
+++ b/lib/PropelConnect.js
@@ -264,7 +264,7 @@ ${JSON.stringify(data, null, 2)}
 --a7V4kRcFA8E79pivMuV2tukQ85cmNKeoEgJgq--`
 
       const options = {
-        hostname: this.serverUrl,
+        hostname: this.serverUrl.replace('https://', ''),
         path: '/services/data/v23.0/sobjects/ContentVersion/',
         method: 'POST',
         headers: {


### PR DESCRIPTION
The old service takes the url without `https` but the new one is included in the connection. But the upload file use a different API need no https

On PLM import:
[serverUrl: 'https://' + this.serverUrl,](https://github.com/PropelPLM/propel-import-app/blob/1cca7fb55b62d51bb892afa5b6d13591b6da2e49/lib/ImportService.js#L32)