### PR TITLE
Fix parsing of Record IDs in DML results

### DIFF
--- a/lib/PropelLog.js
+++ b/lib/PropelLog.js
@@ -17,7 +17,7 @@ class PropelLog {
       results.forEach(result => {
         this.logs.push({
           errors: result.errors.map((e) => '' + e),
-          record_id: result.Id,
+          record_id: result.Id ?? result.id,
           sobject_name: sObjectName,
           success: result.success,
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@propelsoftwaresolutions/propel-sfdc-connect",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Wrapper module for jforce-propel",
   "exports": "./index.js",
   "scripts": {


### PR DESCRIPTION
Fix a bug to look for `result.id` if `result.Id` is null.
This was `PropelLog` before:
![image](https://github.com/PropelPLM/propel-sfdc-connect/assets/32610179/a974e7a5-b45e-41a2-8787-734886e4b280)
